### PR TITLE
Enable mutation-based duplicate check tests

### DIFF
--- a/lib/hooks/use-duplicate-check.test.tsx
+++ b/lib/hooks/use-duplicate-check.test.tsx
@@ -6,7 +6,7 @@ import { TestProviders, createTestQueryClient } from '@/lib/test-utils'
 // Mock fetch
 global.fetch = vi.fn()
 
-describe.skip('useDuplicateCheck', () => {
+describe('useDuplicateCheck', () => {
   const mockFetch = global.fetch as ReturnType<typeof vi.fn>
   let queryClient: ReturnType<typeof createTestQueryClient>
 
@@ -19,147 +19,97 @@ describe.skip('useDuplicateCheck', () => {
     <TestProviders queryClient={queryClient}>{children}</TestProviders>
   )
 
-  it('should not check when title is empty', () => {
-    renderHook(() => useDuplicateCheck(''), { wrapper })
-
-    expect(mockFetch).not.toHaveBeenCalled()
-  })
-
-  it('should check for duplicates with debounced title', async () => {
+  it('calls the API and returns data on success', async () => {
+    const responseData = { duplicates: [], totalChecked: 1 }
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ duplicates: [] }),
+      json: async () => responseData,
     } as Response)
 
-    const { result } = renderHook(() => useDuplicateCheck('Chocolate Cake'), { wrapper })
+    const { result } = renderHook(() => useDuplicateCheck(), { wrapper })
 
-    // Initially should be idle
-    expect(result.current.isChecking).toBe(false)
-
-    // Wait for debounce and query to execute
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalledWith(
-        '/api/recipes/check-duplicates?title=Chocolate%20Cake'
-      )
+    await act(async () => {
+      await result.current.mutateAsync({ title: 'Chocolate Cake' })
     })
 
+    expect(mockFetch).toHaveBeenCalledWith(
+      '/api/recipes/check-duplicates',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'Chocolate Cake' }),
+      })
+    )
     await waitFor(() => {
-      expect(result.current.duplicates).toEqual([])
-      expect(result.current.isChecking).toBe(false)
+      expect(result.current.data).toEqual(responseData)
+      expect(result.current.isError).toBe(false)
     })
   })
 
-  it('should return duplicate recipes', async () => {
-    const mockDuplicates = [
-      { id: '1', title: 'Chocolate Cake' },
-      { id: '2', title: 'Chocolate Cake Recipe' },
-    ]
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ duplicates: mockDuplicates }),
-    } as Response)
-
-    const { result } = renderHook(() => useDuplicateCheck('Chocolate Cake'), { wrapper })
-
-    await waitFor(() => {
-      expect(result.current.duplicates).toEqual(mockDuplicates)
-      expect(result.current.isChecking).toBe(false)
-    })
-  })
-
-  it('should handle API errors gracefully', async () => {
+  it('sets an error when the API response is not ok', async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,
-      status: 500,
       json: async () => ({ error: 'Server error' }),
     } as Response)
 
-    const { result } = renderHook(() => useDuplicateCheck('Test Recipe'), { wrapper })
+    const { result } = renderHook(() => useDuplicateCheck(), { wrapper })
 
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-    })
-
-    await waitFor(() => {
-      expect(result.current.duplicates).toEqual([])
-      expect(result.current.isChecking).toBe(false)
-    })
-  })
-
-  it('should handle network errors', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Network error'))
-
-    const { result } = renderHook(() => useDuplicateCheck('Test Recipe'), { wrapper })
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
-    })
-
-    await waitFor(() => {
-      expect(result.current.duplicates).toEqual([])
-      expect(result.current.isChecking).toBe(false)
-    })
-  })
-
-  it('should update when title changes', async () => {
-    const { rerender } = renderHook(
-      ({ title }) => useDuplicateCheck(title),
-      {
-        wrapper,
-        initialProps: { title: 'Cake' },
-      }
-    )
-
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ duplicates: [{ id: '1', title: 'Cake Recipe' }] }),
-    } as Response)
-
-    // Change the title
-    rerender({ title: 'Chocolate Cake' })
-
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenLastCalledWith(
-        '/api/recipes/check-duplicates?title=Chocolate%20Cake'
+    await act(async () => {
+      await expect(result.current.mutateAsync({ title: 'Bad Recipe' })).rejects.toThrow(
+        'Server error'
       )
     })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+      expect(result.current.error).toBeInstanceOf(Error)
+    })
   })
 
-  it('should handle the isChecking state correctly', async () => {
+  it('handles network errors', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+
+    const { result } = renderHook(() => useDuplicateCheck(), { wrapper })
+
+    await act(async () => {
+      await expect(result.current.mutateAsync({ title: 'Test Recipe' })).rejects.toThrow(
+        'Network error'
+      )
+    })
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true)
+      expect(result.current.error).toBeInstanceOf(Error)
+    })
+  })
+
+  it('reflects pending state while the request is in flight', async () => {
     let resolvePromise: (value: Response) => void
     const promise = new Promise<Response>((resolve) => {
       resolvePromise = resolve
     })
 
-    mockFetch.mockReturnValueOnce(promise)
+    mockFetch.mockReturnValueOnce(promise as unknown as Promise<Response>)
 
-    const { result } = renderHook(() => useDuplicateCheck('Slow Recipe'), { wrapper })
+    const { result } = renderHook(() => useDuplicateCheck(), { wrapper })
 
-    // Should not be checking immediately (debounce)
-    expect(result.current.isChecking).toBe(false)
-
-    // Wait for debounce
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled()
+    act(() => {
+      result.current.mutate({ title: 'Slow Recipe' })
     })
 
-    // Should be checking while request is pending
     await waitFor(() => {
-      expect(result.current.isChecking).toBe(true)
+      expect(result.current.isPending).toBe(true)
     })
 
-    // Resolve the request
     act(() => {
       resolvePromise({
         ok: true,
-        json: async () => ({ duplicates: [] }),
+        json: async () => ({ duplicates: [], totalChecked: 0 }),
       } as Response)
     })
 
-    // Should not be checking after request completes
     await waitFor(() => {
-      expect(result.current.isChecking).toBe(false)
+      expect(result.current.isPending).toBe(false)
     })
   })
 })


### PR DESCRIPTION
## Summary
- rewrite the useDuplicateCheck tests for mutation-based API
- re-enable the test suite

## Testing
- `pnpm test --run lib/hooks/use-duplicate-check.test.tsx`
- `pnpm test --run`

------
https://chatgpt.com/codex/tasks/task_e_6858216ae0588332a46895a135e457e5