### PR TITLE
Align pnpm version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   NODE_VERSION: '20'
-  PNPM_VERSION: '8'
+  PNPM_VERSION: '10.11.0'
 
 jobs:
   lint:


### PR DESCRIPTION
## Summary
- match pnpm version with package.json in GitHub Actions

## Testing
- `pnpm lint`
- `pnpm test:unit`
- `pnpm tsc --noEmit` *(fails: Cannot find name 'expect')*

------
https://chatgpt.com/codex/tasks/task_e_6858235014648332987e4e83eaad71bc